### PR TITLE
update some railsbytes links to be .com

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ For non-ruby projects, you'll need to install ruby, and then `gem install bloat`
 
 ## Usage
 
-Just run `bloat with {template_url}`, and the content at the template will be run from your current directory! For examples of what you might want to do, check out [RailsBytes](https://railsbytes.org).
+Just run `bloat with {template_url}`, and the content at the template will be run from your current directory! For examples of what you might want to do, check out [RailsBytes](https://railsbytes.com).
 
 ## Examples
 
-Let's check out using `bloat` to make templates from [RailsBytes](https://railsbytes.org) work in a [Lucky](https://luckyframework.org) application.
+Let's check out using `bloat` to make templates from [RailsBytes](https://railsbytes.com) work in a [Lucky](https://luckyframework.org) application.
 
 #### We can add the lovely [StimulusJS](https://stimulusjs.org) library to Lucky our app with one command!
 


### PR DESCRIPTION
these links were not working for me.  Seems like there is no .org but there is a .com.